### PR TITLE
Add `yields` helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-cli": "^6.7.7",
     "babel-core": "^6.7.7",
     "babel-eslint": "^6.0.4",
+    "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-register": "^6.7.2",

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,16 @@ export default function testSaga(
 
       return api;
     },
+
+    yields: (value) => (fun) => {
+      if (typeof fun !== 'function') {
+        throw new Error('must pass a function to yields');
+      }
+
+      fun(value);
+
+      return api
+    }
   };
 
   function createIterator(): Generator {
@@ -115,7 +125,8 @@ export default function testSaga(
       take: effectsTestersCreators.take(value),
       takem: effectsTestersCreators.takem(value),
       is: effectsTestersCreators.is(value),
-      isDone: effectsTestersCreators.isDone(done),
+      yields: effectsTestersCreators.yields(value),
+      isDone: effectsTestersCreators.isDone(done)
     };
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -30,6 +30,7 @@ export type ApiWithEffectsTesters = {
   take: EffectTester;
   takem: EffectTester;
   is: EffectTester;
+  yields: EffectTester;
   isDone: EffectTester;
 };
 
@@ -75,5 +76,6 @@ export type EffectTestersCreator = {
   take: EffectTesterCreator;
   takem: EffectTesterCreator;
   is: EffectTesterCreator;
+  yields: EffectTesterCreator;
   isDone: EffectTesterCreator;
 };

--- a/test/testSaga.test.js
+++ b/test/testSaga.test.js
@@ -182,3 +182,15 @@ test('restarts before done', t => {
       .next().isDone();
   });
 });
+
+test('executes callback passed to yields with actual yielded value', t => {
+  saga
+    .next()
+    .yields((actualValue) => {
+      t.deepEqual(actualValue, take('HELLO'))
+    })
+    .next(action).put({ type: 'ADD', payload: x + y })
+    .next().call(identity, action)
+    .next().fork(otherSaga, z)
+    .next().isDone();
+});


### PR DESCRIPTION
I have a use case where a saga step is building a complex object containing generator functions, which themselves contain saga `put` statements.

Using the `saga.next().is(...)` helper was not enough to properly test these scenarios, so I have added a `yields` helper, an example of this is:

``` javascript
saga
    .next()
    .yields((yieldedValue) => {
      expect(yieldedValue).to.have.all.keys(['ready', 'error'])
      const readyHandler = testSaga(yieldedValue.ready)
      readyHandler.next().put(...)
      readyHandler.next().put(...)
      ...etc
    })
```
