### PR TITLE
Add named marks that you can back up to

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -147,10 +147,10 @@ export default function testSaga(
   saga: Function,
   ...sagaArgs: Array<any>
 ): Api {
-  const api = { next, back, finish, restart, mark, gotoMark, throw: throwError };
+  const api = { next, back, finish, restart, save, restore, throw: throwError };
 
   let previousArgs: Array<Arg> = [];
-  let marks: Object<String, Number> = {};
+  let savePoints: Object<String, Number> = {};
   let iterator = createIterator();
 
   function createEffectTester(
@@ -297,14 +297,14 @@ export default function testSaga(
     return apiWithEffectsTesters(result);
   }
 
-  function gotoMark(name: string): Api {
-    if (!marks[name]) {
-      throw new Error(`No such mark ${name}`);
+  function restore(name: string): Api {
+    if (!savePoints[name]) {
+      throw new Error(`No such save point ${name}`);
     }
 
     iterator = createIterator();
-    previousArgs = marks[name];
-    return applyHistory(marks[name]);
+    previousArgs = savePoints[name];
+    return applyHistory(savePoints[name]);
   }
 
   function back(n: number = 1): Api {
@@ -323,8 +323,8 @@ export default function testSaga(
     return applyHistory(previousArgs);
   }
 
-  function mark(name: string): Api {
-    marks[name] = previousArgs.slice(0);
+  function save(name: string): Api {
+    savePoints[name] = previousArgs.slice(0);
     return api;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -254,7 +254,6 @@ export default function testSaga(
 
   function restart(): Api {
     previousArgs = [];
-    marks = {};
     iterator = createIterator();
 
     return api;
@@ -304,7 +303,7 @@ export default function testSaga(
     }
 
     iterator = createIterator();
-
+    previousArgs = marks[name];
     return applyHistory(marks[name]);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,7 @@ export default function testSaga(
   const api = { next, back, finish, restart, save, restore, throw: throwError };
 
   let previousArgs: Array<Arg> = [];
-  let savePoints: Object<String, Number> = {};
+  const savePoints: { [key: string]: Array<Arg> } = {};
   let iterator = createIterator();
 
   function createEffectTester(

--- a/src/types.js
+++ b/src/types.js
@@ -31,7 +31,7 @@ export type ApiWithEffectsTesters = Api & {
 };
 
 export type Progresser = (...args: Array<any>) => ApiWithEffectsTesters;
-export type Back = (n: number | void | string) => Api;
+export type Back = (n: number | void) => Api;
 export type Restart = () => Api;
 export type ThrowError = (error: Error) => ApiWithEffectsTesters;
 

--- a/src/types.js
+++ b/src/types.js
@@ -5,6 +5,8 @@ export type Api = {
   next: Progresser;
   finish: Progresser;
   back: Back;
+  save: SaveRestore;
+  restore: SaveRestore;
   restart: Restart;
   throw: ThrowError;
 };
@@ -32,6 +34,7 @@ export type ApiWithEffectsTesters = Api & {
 
 export type Progresser = (...args: Array<any>) => ApiWithEffectsTesters;
 export type Back = (n: number | void) => Api;
+export type SaveRestore = (s: string) => Api;
 export type Restart = () => Api;
 export type ThrowError = (error: Error) => ApiWithEffectsTesters;
 

--- a/src/types.js
+++ b/src/types.js
@@ -31,7 +31,7 @@ export type ApiWithEffectsTesters = Api & {
 };
 
 export type Progresser = (...args: Array<any>) => ApiWithEffectsTesters;
-export type Back = (n?: number) => Api;
+export type Back = (n: number | void | string) => Api;
 export type Restart = () => Api;
 export type ThrowError = (error: Error) => ApiWithEffectsTesters;
 

--- a/test/testSaga.test.js
+++ b/test/testSaga.test.js
@@ -98,6 +98,40 @@ test('can back up multiple steps', () => {
     .take('HELLO');
 });
 
+test('can back up to a named mark', () => {
+  saga
+    .next()
+    .take('HELLO')
+
+    .mark('pre put(add)')
+
+    .next(action)
+    .put({ type: 'ADD', payload: x + y })
+
+    .next()
+    .call(identity, action)
+
+    .back('pre put(add)')
+
+    .next(action)
+    .put({ type: 'ADD', payload: x + y });
+});
+
+test('cannot back up to invalid mark', t => {
+  t.throws(_ => {
+    saga
+      .next()
+      .take('HELLO')
+
+      .mark('pre put(add)')
+
+      .next(action)
+      .put({ type: 'ADD', payload: x + y })
+
+      .back('foo bar baz');
+  });
+});
+
 test('cannot back up at start', t => {
   t.throws(_ => {
     saga.back();

--- a/test/testSaga.test.js
+++ b/test/testSaga.test.js
@@ -98,12 +98,12 @@ test('can back up multiple steps', () => {
     .take('HELLO');
 });
 
-test('can back up to a named mark', () => {
+test('can back up to a named save point', () => {
   saga
     .next()
     .take('HELLO')
 
-    .mark('pre put(add)')
+    .save('pre put(add)')
 
     .next(action)
     .put({ type: 'ADD', payload: x + y })
@@ -111,12 +111,12 @@ test('can back up to a named mark', () => {
     .next()
     .call(identity, action)
 
-    .gotoMark('pre put(add)')
+    .restore('pre put(add)')
 
     .next(action)
     .put({ type: 'ADD', payload: x + y })
 
-    .mark('post put(add)')
+    .save('post put(add)')
 
     .back(1)
 
@@ -127,23 +127,23 @@ test('can back up to a named mark', () => {
     .next()
     .take('HELLO')
 
-    .gotoMark('post put(add)')
+    .restore('post put(add)')
     .next()
     .call(identity, action);
 });
 
-test('cannot back up to invalid mark', t => {
+test('cannot back up to invalid save point', t => {
   t.throws(_ => {
     saga
       .next()
       .take('HELLO')
 
-      .mark('pre put(add)')
+      .save('pre put(add)')
 
       .next(action)
       .put({ type: 'ADD', payload: x + y })
 
-      .gotoMark('foo bar baz');
+      .restore('foo bar baz');
   });
 });
 

--- a/test/testSaga.test.js
+++ b/test/testSaga.test.js
@@ -114,7 +114,22 @@ test('can back up to a named mark', () => {
     .gotoMark('pre put(add)')
 
     .next(action)
-    .put({ type: 'ADD', payload: x + y });
+    .put({ type: 'ADD', payload: x + y })
+
+    .mark('post put(add)')
+
+    .back(1)
+
+    .next(action)
+    .put({ type: 'ADD', payload: x + y })
+
+    .restart()
+    .next()
+    .take('HELLO')
+
+    .gotoMark('post put(add)')
+    .next()
+    .call(identity, action);
 });
 
 test('cannot back up to invalid mark', t => {

--- a/test/testSaga.test.js
+++ b/test/testSaga.test.js
@@ -111,7 +111,7 @@ test('can back up to a named mark', () => {
     .next()
     .call(identity, action)
 
-    .back('pre put(add)')
+    .gotoMark('pre put(add)')
 
     .next(action)
     .put({ type: 'ADD', payload: x + y });
@@ -128,7 +128,7 @@ test('cannot back up to invalid mark', t => {
       .next(action)
       .put({ type: 'ADD', payload: x + y })
 
-      .back('foo bar baz');
+      .gotoMark('foo bar baz');
   });
 });
 


### PR DESCRIPTION
Rather than backing up a hardcoded number of steps which can be brittle if your saga changes, this PR lets you create named "marks" using the `mark` function. You can pass this name to `back` to return to that point.