### PR TITLE
Fix saga promise handling

### DIFF
--- a/__tests__/expectSaga/expectSaga.test.js
+++ b/__tests__/expectSaga/expectSaga.test.js
@@ -51,6 +51,7 @@ test('silences warnings with forks', async () => {
   warn.mockClear();
 
   function* otherSaga() {
+    yield 42;
   }
 
   function* saga() {
@@ -186,13 +187,14 @@ test('times out even if promises keep getting added', async () => {
 
   function* otherSaga() {
     yield takeEvery('FOO', function* handler() {
+      yield 42;
     });
   }
 
   function* sagas() {
     yield [
       fork(saga),
-      fork(otherSaga)
+      fork(otherSaga),
     ];
   }
 


### PR DESCRIPTION
Hey man, awesome project! Did run into some issues when I was trying to do some more complex integration tests with expectSaga. Turns out the stopDirty behaviour was the cause of this. I hope I understood correctly what that was supposed to do, because removing it didn't break any tests.

Listed my changes below. Please let me know if anything is not OK. Thanks!

Fixed and added tests for:
- expectSaga ignored the silenceTimeout flag when any kind of fork was involved.
- forks caused the exportSaga timeout period to be extended. Whenever a fork was added expectSaga would reset the timeout. Adding a fork once would result in timeout period times 2. Keep adding forks and expectSaga would never time out.

Added test (to make sure nothing broke with this change):
- expectSaga waiting for all promises to resolve (if they resolve within the timeout)

The fix is to move the stopDirty behaviour, so that getAllPromises never resolves before all promises are resolved. This makes sure that cancelMainTask doesn’t have to call scheduleStop, as that call caused issues with silenceTimout not being passed, and the timeout resetting.