### PR TITLE
Test on Node 7 and take advantage of TravisCI's yarn support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-cache:
-  directories:
-    - $HOME/.yarn-cache
+cache: yarn
 
 language: node_js
 
@@ -8,6 +6,7 @@ node_js:
   - "4"
   - "5"
   - "6"
+  - "7"
 
 branches:
   only:
@@ -15,19 +14,10 @@ branches:
     - dev
     - /^greenkeeper.*$/
 
-before_install:
-  # Yarn
-  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
-
-install: yarn
-
 script:
-  - npm run lint
-  - npm run typecheck
-  - npm test
+  - yarn run lint
+  - yarn run typecheck
+  - yarn test
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
According to [this](https://blog.travis-ci.com/2016-11-21-travis-ci-now-supports-yarn), Travis CI supports yarn out of the box if `yarn.lock` is present, without needing to manually install it.

Also, since Node 7 is the latest version, it seemed appropriate to add it to the list of CI builds.