### PR TITLE
expectSaga does not wait for Promises to resolve

### DIFF
--- a/__tests__/expectSaga/expectSaga.test.js
+++ b/__tests__/expectSaga/expectSaga.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-constant-condition */
-import { take, takeEvery, fork, join, put, spawn } from 'redux-saga/effects';
+import { call, take, takeEvery, fork, join, put, spawn } from 'redux-saga/effects';
 import { warn } from 'utils/logging';
 import { delay } from 'utils/async';
 import expectSaga from 'expectSaga';
@@ -271,4 +271,27 @@ test('ignores effects without effect store', () => {
   return expectSaga(saga)
     .put({ type: 'DONE' })
     .run();
+});
+
+test('terminates and does not wait for Call effect Promises', async () => {
+  warn.mockClear();
+  function endpoint() {
+    return Promise.reject();
+  }
+
+  function* saga() {
+    try {
+      while (true) {
+        yield call(endpoint);
+        yield call(delay, 200);
+      }
+    } catch (e) {
+      yield put({ type: 'DONE' });
+    }
+  }
+
+  await expectSaga(saga)
+  .run(false);
+
+  expect(warn).not.toHaveBeenCalled();
 });

--- a/src/expectSaga/index.js
+++ b/src/expectSaga/index.js
@@ -253,7 +253,6 @@ export default function expectSaga(generator: Function, ...sagaArgs: mixed[]): E
   function getAllPromises(): Promise<*> {
     return new Promise(resolve => {
       Promise.all([
-        ...effectStores[PROMISE].values(),
         ...forkedTasks.map(task => task.done),
         mainTaskPromise,
       ]).then(() => {


### PR DESCRIPTION
This is related to #123 
Also the included test case will actually timeout and fail in the current implementation. Because although the MainTask.done will resolve, expectSaga will keep waiting for the Promise returned by endPoint to resolve, however it won't because it's rejected. 
```
  function endpoint() {
    return Promise.reject();
  }
```
May I have your feedback on this ^_^ 
 
