### PR TITLE
Omit the Promise.resolve to execute reducer in same tick

### DIFF
--- a/__tests__/expectSaga/reducer/sequential.test.js
+++ b/__tests__/expectSaga/reducer/sequential.test.js
@@ -1,0 +1,54 @@
+// @flow
+import { put, select, take } from 'redux-saga/effects';
+import expectSaga from 'expectSaga';
+
+const READY = 'READY';
+const BARK = 'BARK';
+const BARK_COUNT_BEFORE = 'BARK_COUNT_BEFORE';
+const BARK_COUNT_AFTER = 'BARK_COUNT_AFTER';
+
+const initialDog = {
+  name: 'Tucker',
+  barkCount: 11,
+};
+
+function dogReducer(state = initialDog, action) {
+  if (action.type === BARK) {
+    return {
+      ...state,
+      barkCount: state.barkCount + 1,
+    };
+  }
+
+  return state;
+}
+
+function getBarkCount(state) {
+  return state.barkCount;
+}
+
+function* saga() {
+  yield take(READY);
+
+  const barkCountBefore = yield select(getBarkCount);
+
+  yield put({ type: BARK_COUNT_BEFORE, payload: barkCountBefore });
+
+  yield put({ type: BARK });
+
+  const barkCountAfter = yield select(getBarkCount);
+
+  yield put({ type: BARK_COUNT_AFTER, payload: barkCountAfter });
+}
+
+test('handles puts from within saga sequentially', () => (
+  expectSaga(saga)
+    .withReducer(dogReducer)
+
+    .put({ type: BARK_COUNT_BEFORE, payload: 11 })
+    .put({ type: BARK_COUNT_AFTER, payload: 12 })
+
+    .dispatch({ type: READY })
+
+    .run()
+));

--- a/src/expectSaga/index.js
+++ b/src/expectSaga/index.js
@@ -330,21 +330,15 @@ export default function expectSaga(generator: Function, ...sagaArgs: mixed[]): E
     if (typeof action._delayTime === 'number') {
       const { _delayTime } = action;
 
-      function handler() {
-        storeState = reducer(storeState, action);
-        notifyListeners(action)
-      }
-
       dispatchPromise
         .then(() => delay(_delayTime))
-        .then(handler);
+        .then(() => {
+          storeState = reducer(storeState, action);
+          notifyListeners(action);
+        });
     } else {
-      function handler() {
-        notifyListeners(action);
-      }
-
       storeState = reducer(storeState, action);
-      dispatchPromise.then(handler);
+      dispatchPromise.then(() => notifyListeners(action));
     }
   }
 

--- a/src/expectSaga/index.js
+++ b/src/expectSaga/index.js
@@ -327,18 +327,23 @@ export default function expectSaga(generator: Function, ...sagaArgs: mixed[]): E
   }
 
   function dispatch(action: Action): any {
-    function handler() {
-      storeState = reducer(storeState, action);
-      notifyListeners(action);
-    }
-
     if (typeof action._delayTime === 'number') {
       const { _delayTime } = action;
+
+      function handler() {
+        storeState = reducer(storeState, action);
+        notifyListeners(action)
+      }
 
       dispatchPromise
         .then(() => delay(_delayTime))
         .then(handler);
     } else {
+      function handler() {
+        notifyListeners(action);
+      }
+
+      storeState = reducer(storeState, action);
       dispatchPromise.then(handler);
     }
   }


### PR DESCRIPTION
During saga test the actions dispatched from within a saga are not executed instantly which results in a wrong execution order for the tests.

We encountered this in a saga where a selector is performed right after a dispatched action, using the `withReducer` option. The store was not yet updated when the selector was executed, meaning the saga failed based on incorrect data.

This is a simple solution that only delays the store execution when a delayTime is given.