### PR TITLE
Add error assertion to expectSaga

### DIFF
--- a/__tests__/expectSaga/assertions/throws.test.js
+++ b/__tests__/expectSaga/assertions/throws.test.js
@@ -45,9 +45,18 @@ test('fails when no error thrown', done =>
       done();
     }));
 
-test('fails when non-matching error thrown', done =>
+test('fails when non-matching error type thrown', done =>
   expectSaga(errorSaga, new Error())
     .throws(CustomError)
+    .run()
+    .catch(e => {
+      expect(e.message).toMatch(/but instead threw/i);
+      done();
+    }));
+
+test('fails when non-matching error value thrown', done =>
+  expectSaga(errorSaga, { message: 'Error 1' })
+    .throws({ message: 'Error 2' })
     .run()
     .catch(e => {
       expect(e.message).toMatch(/but instead threw/i);

--- a/__tests__/expectSaga/assertions/throws.test.js
+++ b/__tests__/expectSaga/assertions/throws.test.js
@@ -1,0 +1,90 @@
+/* eslint-disable require-yield */
+import { put, call } from 'redux-saga/effects';
+import expectSaga from 'expectSaga';
+
+import * as matchers from '../../../matchers';
+import { throwError } from '../../../providers';
+
+class CustomError {}
+
+function* noErrorSaga() {
+  yield put({ type: 'TEST_1' });
+  yield put({ type: 'TEST_2' });
+}
+
+function* errorSaga(errorToThrow) {
+  throw errorToThrow;
+}
+
+test('matches based on error type', () =>
+  expectSaga(errorSaga, new CustomError('Error Message'))
+    .throws(CustomError)
+    .run());
+
+test('matches based on error value', () => {
+  const customErrorInstance = new CustomError();
+
+  return expectSaga(errorSaga, customErrorInstance)
+    .throws(customErrorInstance)
+    .run();
+});
+
+test('matches plain error object by value', () =>
+  expectSaga(errorSaga, { message: 'foo' })
+    .throws({ message: 'foo' })
+    .run());
+
+test('fails when no error thrown', done =>
+  expectSaga(noErrorSaga)
+    .put({ type: 'TEST_1' })
+    .put({ type: 'TEST_2' })
+    .throws(CustomError)
+    .run()
+    .catch(e => {
+      expect(e.message).toMatch(/but no error thrown/i);
+      done();
+    }));
+
+test('fails when non-matching error thrown', done =>
+  expectSaga(errorSaga, new Error())
+    .throws(CustomError)
+    .run()
+    .catch(e => {
+      expect(e.message).toMatch(/but instead threw/i);
+      done();
+    }));
+
+test('checks other expectations when matching error thrown', done =>
+  expectSaga(errorSaga, new CustomError())
+    .put({ type: 'TEST_3' })
+    .throws(CustomError)
+    .run()
+    .catch(e => {
+      expect(e.message).toMatch(/put expectation unmet/i);
+      done();
+    }));
+
+test('negative assertion passes when no error thrown', () =>
+  expectSaga(noErrorSaga)
+    .not.throws(CustomError)
+    .run());
+
+test('negative assertion fails when matching error thrown', done =>
+  expectSaga(errorSaga, new CustomError())
+    .not.throws(CustomError)
+    .run()
+    .catch(e => {
+      expect(e.message).toMatch(/expected not to throw/i);
+      done();
+    }));
+
+test('exception bubbles up when no error expected', done => {
+  const errorValue = new Error();
+
+  return expectSaga(errorSaga, errorValue)
+    .run()
+    .catch(e => {
+      expect(e).toBe(errorValue);
+      done();
+    });
+});

--- a/__tests__/expectSaga/assertions/throws.test.js
+++ b/__tests__/expectSaga/assertions/throws.test.js
@@ -1,9 +1,6 @@
 /* eslint-disable require-yield */
-import { put, call } from 'redux-saga/effects';
+import { put } from 'redux-saga/effects';
 import expectSaga from 'expectSaga';
-
-import * as matchers from '../../../matchers';
-import { throwError } from '../../../providers';
 
 class CustomError {}
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,6 +15,7 @@
   - [Exposed Effects](/integration-testing/exposed-effects.md)
   - [Snapshot Testing](/integration-testing/snapshot-testing.md)
   - [Return Value](/integration-testing/return-value.md)
+  - [Thrown Errors](/integration-testing/thrown-errors.md)
   - [Forked Sagas](/integration-testing/forked-sagas.md)
 - [Unit Testing](/unit-testing/README.md)
   - [Error Messages](/unit-testing/error-messages.md)

--- a/docs/integration-testing/thrown-errors.md
+++ b/docs/integration-testing/thrown-errors.md
@@ -1,0 +1,79 @@
+# Thrown Errors
+
+You can assert that the saga throws a particular error using the `throws` method:
+
+```js
+function* saga() {
+  throw new Error();
+}
+
+it('throws an error of type Error', () => {
+  return expectSaga(saga)
+    .throws(Error)
+    .run();
+});
+```
+
+It is also possible to match errors by [exact] value, which is useful for matching plain object errors:
+
+```js
+function* saga() {
+  throw { message: 'Plain Object Error' };
+}
+
+it('throws a plain object error', () => {
+  return expectSaga(saga)
+    .throws({ message: 'Plain Object Error' })
+    .run();
+});
+```
+
+Other assertions are also checked when an error is thrown. This can be used to verify cleanup code etc:
+
+```js
+function* saga() {
+  yield put({ type: 'API_STARTED' });
+
+  try {
+    yield call(callApi, '/users/', 'get');
+  } catch (e) {
+    yield put({ type: 'API_FAILED' });
+    throw e;
+  }
+
+  yield put({ type: 'API_SUCCESS' });
+}
+
+it('cleans up on API error', () =>
+  expectSaga(saga)
+    .provide([
+      [matchers.call.fn(callApi), throwError(apiError)],
+    ])
+    .put({ type: 'API_STARTED' })
+    .call.fn(callApi)
+    .put({ type: 'API_FAILED' })
+    .throws(apiError)
+    .run());
+```
+
+
+Negated assertions also work, however you must be wary that if the saga throws errors that don't match, the test will pass silently:
+```js
+function* saga() {
+  throw new Error();
+}
+
+// This test will pass!
+it('doesnt throw an error of type CustomErrorType', () => {
+  return expectSaga(saga)
+    .not.throws(CustomErrorType)
+    .run();
+});
+
+// This test will fail
+it('doesnt throw an error of type Error', () => {
+  return expectSaga(saga)
+    .not.throws(Error)
+    .run();
+});
+```

--- a/docs/integration-testing/thrown-errors.md
+++ b/docs/integration-testing/thrown-errors.md
@@ -29,7 +29,6 @@ it('throws a plain object error', () => {
 ```
 
 Other assertions are also checked when an error is thrown. This can be used to verify cleanup code etc:
-
 ```js
 function* saga() {
   yield put({ type: 'API_STARTED' });

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,7 @@ export interface ExpectApi extends ExpectApiEffects {
     withReducer<S>(newReducer: Reducer<S>, initialState?: S): ExpectApi;
     hasFinalState<S>(state: S): ExpectApi;
     returns(value: any): ExpectApi;
+    throws(type: any): ExpectApi;
     delay(time: number): ExpectApi;
     dispatch<A extends Action>(action: A): ExpectApi;
     not: ExpectApi;

--- a/src/expectSaga/expectations.js
+++ b/src/expectSaga/expectations.js
@@ -10,6 +10,7 @@ import reportActualEffects from './reportActualEffects';
 type ExpectationThunkArgs = {
   storeState: mixed,
   returnValue: mixed,
+  errorValue: mixed,
 };
 
 export type Expectation = ExpectationThunkArgs => void;
@@ -136,6 +137,66 @@ ${serializedExpected}
 `;
 
       throw new SagaTestError(errorMessage);
+    }
+  };
+}
+
+type ErrorExpectationArgs = {
+  type: mixed,
+  expected: boolean,
+};
+
+export function createErrorExpectation({
+  type,
+  expected,
+}: ErrorExpectationArgs): Expectation {
+  return ({ errorValue }: ExpectationThunkArgs) => {
+    const serializedExpected =
+      typeof type === 'object' ? inspect(type, { depth: 3 }) : type.name;
+
+    const matches = () =>
+      (typeof type === 'object' && isEqual(type, errorValue)) ||
+      (typeof type === 'function' && errorValue instanceof type);
+
+    if (!expected) {
+      if (typeof errorValue === 'undefined' || !matches()) return;
+
+      throw new SagaTestError(`
+Expected not to throw:
+----------------------
+${serializedExpected}
+`);
+    } else if (typeof errorValue === 'undefined') {
+      throw new SagaTestError(`
+Expected to thow:
+-------------------
+${serializedExpected}
+
+But no error thrown
+---------------------
+`);
+    } else if (typeof type === 'object' && !matches()) {
+      const serializedActual = inspect(errorValue, { depth: 3 });
+      throw new SagaTestError(`
+Expected to throw:
+-------------------
+${serializedExpected}
+
+But instead threw:
+---------------------
+${serializedActual}
+`);
+    } else if (typeof type === 'function' && !matches()) {
+      const serializedActual = errorValue.constructor.name;
+      throw new SagaTestError(`
+Expected to throw error of type:
+--------------------------------
+${serializedExpected}
+
+But instead threw:
+--------------------------------
+${serializedActual}
+`);
     }
   };
 }

--- a/src/expectSaga/expectations.js
+++ b/src/expectSaga/expectations.js
@@ -151,8 +151,13 @@ export function createErrorExpectation({
   expected,
 }: ErrorExpectationArgs): Expectation {
   return ({ errorValue }: ExpectationThunkArgs) => {
-    const serializedExpected =
-      typeof type === 'object' ? inspect(type, { depth: 3 }) : type.name;
+    let serializedExpected = typeof type;
+
+    if (typeof type === 'object') {
+      serializedExpected = inspect(type, { depth: 3 });
+    } else if (typeof type === 'function') {
+      serializedExpected = type.name;
+    }
 
     const matches = () =>
       (typeof type === 'object' && isEqual(type, errorValue)) ||
@@ -187,7 +192,11 @@ But instead threw:
 ${serializedActual}
 `);
     } else if (typeof type === 'function' && !matches()) {
-      const serializedActual = errorValue.constructor.name;
+      const serializedActual =
+        typeof errorValue === 'function'
+          ? errorValue.constructor.name
+          : typeof errorValue;
+
       throw new SagaTestError(`
 Expected to throw error of type:
 --------------------------------

--- a/src/expectSaga/index.js
+++ b/src/expectSaga/index.js
@@ -643,7 +643,7 @@ export default function expectSaga(
       .then(checkExpectations)
       // Pass along the error instead of rethrowing or allowing to
       // bubble up to avoid PromiseRejectionHandledWarning
-      .catch(identity);
+      .catch(e => checkExpectations() || e);
 
     return api;
   }


### PR DESCRIPTION
Adds the `throws` method on `expectSaga` which allows for testing of error pathways in sagas. Closes #125 and #147. Fully documented and tested.

Examples:
```js
function* saga() {
  yield put({ type: 'API_STARTED' });

  try {
    yield call(callApi, '/users/', 'get');
  } catch (e) {
    yield put({ type: 'API_FAILED' });
    throw e;
  }

  yield put({ type: 'API_SUCCESS' });
}

it('cleans up on API error', () =>
  expectSaga(saga)
    .provide([
      [matchers.call.fn(callApi), throwError(apiError)],
    ])
    .put({ type: 'API_STARTED' })
    .call.fn(callApi)
    .put({ type: 'API_FAILED' })
    .throws(apiError)
    .run());
```

Failure Example:
```js
function* saga() {
  throw new Error();
}

it('throws an error of type CustomError', () => {
  return expectSaga(saga)
    .throws(CustomError)
    .run();
});
```
```
Expected to throw error of type:
--------------------------------
CustomError

But instead threw:
--------------------------------
Error
```