### PR TITLE
fix: typesafe testSaga & expectSaga

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -105,10 +105,12 @@ export type TestApiWithEffectsTesters = TestApi & TestApiEffects & {
 
 export type SagaType = (...params: any[]) => SagaIterator | IterableIterator<any>;
 
-export interface ExpectSaga {
-    (generator: SagaType, ...sagaArgs: any[]): ExpectApi;
-    DEFAULT_TIMEOUT: number;
-}
+export const expectSaga: (<S extends SagaType>(
+  generator: S,
+  ...sagaArgs: Parameters<S>
+) => ExpectApi) & { DEFAULT_TIMEOUT: number };
 
-export const expectSaga: ExpectSaga;
-export const testSaga: (saga: SagaType, ...params: any[]) => TestApi;
+export const testSaga: <S extends SagaType>(
+  saga: S,
+  ...params: Parameters<S>
+) => TestApi;


### PR DESCRIPTION
When used with typescript, I saw that `testSaga` and `expectSaga` functions were not typesafe with their parameters.

Just used the power of typescript generics to fix that :)
