### PR TITLE
Fix asserting a throw in a catch block

### DIFF
--- a/src/expectSaga/sagaWrapper.js
+++ b/src/expectSaga/sagaWrapper.js
@@ -115,7 +115,14 @@ export default function createSagaWrapper(
       },
 
       throw(e, fsm) {
-        result = wrappedIterator.throw(e);
+        try {
+          result = wrappedIterator.throw(e);
+        } catch (innerError) {
+          if (typeof onError === 'function') {
+            onError(innerError);
+          }
+          throw innerError;
+        }
         return fsm[LOOP](undefined, fsm);
       },
     });


### PR DESCRIPTION
This wraps the `throw` call on the generator to catch any errors that might get thrown in a catch block. Now `expectSaga` can assert on errors thrown in the saga's catch blocks.

Fixes #296