### PR TITLE
Fix the typing of effects that take Channels

### DIFF
--- a/effects.d.ts
+++ b/effects.d.ts
@@ -3,7 +3,7 @@
  * There is no js module backing this up.
  */
 import { Action } from 'redux';
-import { Task, Channel, Buffer } from 'redux-saga';
+import { Task, TakeableChannel, FlushableChannel Buffer } from 'redux-saga';
 import * as E from 'redux-saga/effects';
 
 // Gives you the type of a field K in type T
@@ -11,7 +11,7 @@ type FieldType<T, K extends keyof T> = T[K];
 
 interface TakeEffectApi<R> {
     <T>(pattern?: E.Pattern<T>): R;
-    <T>(channel: Channel<T>): R;
+    <T>(channel: TakeableChannel<T>): R;
 }
 interface PutEffectApi<R> {
     <A extends Action>(action: A): R;
@@ -46,7 +46,7 @@ interface EffectApi<R> {
     all(effects: E.Effect[]): R;
     cancel(task: Task): R;
     cancelled(): R;
-    flush(channel: Channel<any>): R;
+    flush(channel: FlushableChannel<any>): R;
     join(...tasks: Task[]): R;
     delay(ms: number, val?: any): R;
 }

--- a/effects.d.ts
+++ b/effects.d.ts
@@ -3,7 +3,7 @@
  * There is no js module backing this up.
  */
 import { Action } from 'redux';
-import { Task, TakeableChannel, FlushableChannel Buffer } from 'redux-saga';
+import { Task, TakeableChannel, FlushableChannel, Buffer } from 'redux-saga';
 import * as E from 'redux-saga/effects';
 
 // Gives you the type of a field K in type T


### PR DESCRIPTION
Use `TakeableChannel` and `FlushableChannel` instead of `Channel` in effect typings. 

Example that this fixes
```typescript
export function* mySaga() {
  const chan = yield call(makeChannel);

  try {
    while (true) {
      const act = yield take(chan);
      yield put(act);
    }
  } finally {
    if (yield cancelled()) {
      chan.close();
    }
  }
}

const makeChannel = () => eventChannel(emit => {
  emit({ type: 'Hello' })
  return () => { };
});

const channel = makeChannel();

const saga = testSaga(mySaga)
  .next().call(makeChannel)
  // Error happens here
  // Property 'put' is missing in type 'EventChannel<unknown>' but required in type 'Channel<unknown>'
  .next(channel).take(channel)
```
