### PR TITLE
Fix a mistake in the documentation

### DIFF
--- a/docs/integration-testing/exposed-effects.md
+++ b/docs/integration-testing/exposed-effects.md
@@ -22,7 +22,7 @@ it('exposes effects', () => {
   const user = { id, petId, name: 'Jeremy' };
   const pet = { name: 'Tucker' };
 
-  return expectSaga(saga, id)
+  return expectSaga(userSaga, id)
     .provide([
       [call(fetchUser, id), user],
       [call(fetchPet, petId), pet],


### PR DESCRIPTION
It's just a small fix in code sample related to the wrong name of the passed argument. In the code above, we see `userSaga` function.