### PR TITLE
Add action's type to withReducer definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ export interface ExpectApi extends ExpectApiEffects {
     provide(newProviders: EffectProviders): ExpectApi;
     provide(newProviders: (EffectProviders | StaticProvider)[]): ExpectApi;
     withState<S>(state: S): ExpectApi;
-    withReducer<S>(newReducer: Reducer<S>, initialState?: S): ExpectApi;
+    withReducer<S, A extends Action>(newReducer: Reducer<S, A>, initialState?: S): ExpectApi;
     hasFinalState<S>(state: S): ExpectApi;
     returns(value: any): ExpectApi;
     throws(type: any): ExpectApi;


### PR DESCRIPTION
This pull request updates the withReducer type. This needed to provide compatibility with reducers that use more complex action. Such as reducers created with createReducer function from https://github.com/piotrwitek/typesafe-actions
At the moment withReducer allows only AnyAction type.