### PR TITLE
Update restart type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -87,7 +87,7 @@ export interface TestApi {
     back(n?: number): TestApi;
     save(s: string): TestApi;
     restore(s: string): TestApi;
-    restart(): TestApi;
+    restart(...args: any[]): TestApi;
     throw(error: Error): TestApiWithEffectsTesters;
     takeEvery: TakeHelperProgresser;
     takeLatest: TakeHelperProgresser;


### PR DESCRIPTION
Based on [time travel API docs](http://redux-saga-test-plan.jeremyfairbank.com/unit-testing/time-travel.html), `restart` can accept an array of any. So, I fix `restart` type. 