### PR TITLE
Add support for custom inspect options (depth levels & etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ approaches to make testing your sagas easy.
   * [Mocking with Providers](#mocking-with-providers)
   * [Example with Reducer](#example-with-reducer)
 * [Unit Testing](#unit-testing)
+* [Extending inspect options](#extending-inspect-options)
 * [Install](#install)
 
 ## Documentation
@@ -261,6 +262,27 @@ it('works with unit tests', () => {
 
     // assert that the saga is finished
     .isDone();
+});
+```
+
+## Extending inspect options
+To see large effect objects while Expected & Actual result comparison you'll need to extend inspect options. Example:
+```js
+import util from 'util';
+import testSaga from 'redux-saga-test-plan';
+
+import { testableSaga } from '../sagas';
+
+describe('Some sagas to test', () => {
+  util.inspect.defaultOptions.depth = null;
+
+  it('testableSaga', () => {
+    testSaga(testableSaga)
+    .next()
+    .put({ /* large object here */ })
+    .next()
+    .isDone();
+  });
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -82,8 +82,7 @@
     "fsm-iterator": "^1.1.0",
     "lodash.isequal": "^4.5.0",
     "lodash.ismatch": "^4.4.0",
-    "object-assign": "^4.1.0",
-    "util-inspect": "^0.1.8"
+    "object-assign": "^4.1.0"
   },
   "peerDependencies": {
     "redux-saga": "^1.0.1"

--- a/src/expectSaga/expectations.js
+++ b/src/expectSaga/expectations.js
@@ -1,11 +1,13 @@
 // @flow
-import inspect from 'util-inspect';
+import util from 'util';
 import isMatch from 'lodash.ismatch';
 import isEqual from 'lodash.isequal';
 import SagaTestError from '../shared/SagaTestError';
 import type ArraySet from '../utils/ArraySet';
 import serializeEffect from '../shared/serializeEffect';
 import reportActualEffects from './reportActualEffects';
+
+util.inspect.defaultOptions = { depth: 3 };
 
 type ExpectationThunkArgs = {
   storeState: mixed,
@@ -74,8 +76,8 @@ export function createReturnExpectation({
 }: ReturnExpectationArgs): Expectation {
   return ({ returnValue }: ExpectationThunkArgs) => {
     if (expected && !isEqual(value, returnValue)) {
-      const serializedActual = inspect(returnValue, { depth: 3 });
-      const serializedExpected = inspect(value, { depth: 3 });
+      const serializedActual = util.inspect(returnValue);
+      const serializedExpected = util.inspect(value);
 
       const errorMessage = `
 Expected to return:
@@ -89,7 +91,7 @@ ${serializedActual}
 
       throw new SagaTestError(errorMessage);
     } else if (!expected && isEqual(value, returnValue)) {
-      const serializedExpected = inspect(value, { depth: 3 });
+      const serializedExpected = util.inspect(value);
 
       const errorMessage = `
 Did not expect to return:
@@ -113,8 +115,8 @@ export function createStoreStateExpectation({
 }: StoreStateExpectationArgs): Expectation {
   return ({ storeState }: ExpectationThunkArgs) => {
     if (expected && !isEqual(expectedState, storeState)) {
-      const serializedActual = inspect(storeState, { depth: 3 });
-      const serializedExpected = inspect(expectedState, { depth: 3 });
+      const serializedActual = util.inspect(storeState);
+      const serializedExpected = util.inspect(expectedState);
 
       const errorMessage = `
 Expected to have final store state:
@@ -128,7 +130,7 @@ ${serializedActual}
 
       throw new SagaTestError(errorMessage);
     } else if (!expected && isEqual(expectedState, storeState)) {
-      const serializedExpected = inspect(expectedState, { depth: 3 });
+      const serializedExpected = util.inspect(expectedState);
 
       const errorMessage = `
 Expected to not have final store state:
@@ -154,7 +156,7 @@ export function createErrorExpectation({
     let serializedExpected = typeof type;
 
     if (typeof type === 'object') {
-      serializedExpected = inspect(type, { depth: 3 });
+      serializedExpected = util.inspect(type);
     } else if (typeof type === 'function') {
       serializedExpected = type.name;
     }
@@ -181,7 +183,7 @@ But no error thrown
 ---------------------
 `);
     } else if (typeof type === 'object' && !matches()) {
-      const serializedActual = inspect(errorValue, { depth: 3 });
+      const serializedActual = util.inspect(errorValue);
       throw new SagaTestError(`
 Expected to throw:
 -------------------

--- a/src/shared/serializeEffect.js
+++ b/src/shared/serializeEffect.js
@@ -1,7 +1,7 @@
 // @flow
-import inspect from 'util-inspect';
+import util from 'util';
 
-const DEFAULT_OPTIONS = { depth: 4 };
+util.inspect.defaultOptions = { depth: 4 };
 
 export default function serializeEffect(
   effect: mixed | Array<mixed>,
@@ -14,8 +14,8 @@ export default function serializeEffect(
     effectKey &&
     effectKey in effect
   ) {
-    return inspect(effect[effectKey], DEFAULT_OPTIONS);
+    return util.inspect(effect[effectKey]);
   }
 
-  return inspect(effect, DEFAULT_OPTIONS);
+  return util.inspect(effect);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,14 +1360,6 @@ array-includes@^3.1.1:
     es-abstract "^1.17.0"
     is-string "^1.0.5"
 
-array-map@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
-
-array-reduce@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
-
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
@@ -2760,10 +2752,6 @@ for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
-foreach@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.4.tgz#cc5d0d8ae1d46cc9a555c2682f910977859935df"
-
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -3329,10 +3317,6 @@ import-local@^2.0.0:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-
-indexof@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
 
 inflight@^1.0.4, inflight@~1.0.4, inflight@~1.0.6:
   version "1.0.6"
@@ -4157,10 +4141,6 @@ json-stable-stringify@^1.0.1:
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-
-json3@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.0.tgz#0e9e7f6c5d270b758929af4d6fefdc84bd66e259"
 
 json5@^1.0.1:
   version "1.0.1"
@@ -5030,10 +5010,6 @@ object-inspect@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
-
-object-keys@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.5.0.tgz#09e211f3e00318afc4f592e36e7cdc10d9ad7293"
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -6784,18 +6760,6 @@ util-deprecate@~1.0.1:
 util-extend@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f"
-
-util-inspect@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/util-inspect/-/util-inspect-0.1.8.tgz#2b39dbcd2d921f2d8430923caff40f4b5cea5db1"
-  dependencies:
-    array-map "0.0.0"
-    array-reduce "0.0.0"
-    foreach "2.0.4"
-    indexof "0.0.1"
-    isarray "0.0.1"
-    json3 "3.3.0"
-    object-keys "0.5.0"
 
 util.promisify@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR adds support for custom inspect options (depth levels & etc)

Related issues: #95 #339

Example of usage:
```js
import util from 'util';
import testSaga from 'redux-saga-test-plan';
import { put } from 'redux-saga/effects';

const largeAction = {
 type: 'large-action',
 payload: {
  firstLevel: {
   secondLevel: {
     ... // more levels here
   },
  },
 },
};

function* testableSaga() {
 yield put(largeAction)
}

describe('Some sagas to test', () => {
 // this will allow to see the full effect objects while Expected & Actual result comparison in the console 
 util.inspect.defaultOptions.depth = null;

 it('testableSaga', () => {
  testSaga(testableSaga)
   .next()
   .put({
    type: 'large-action',
    payload: { ... },
   })
   .next()
   .isDone();
 });
});
```