### PR TITLE
Update exposed-effects.md

### DIFF
--- a/docs/integration-testing/exposed-effects.md
+++ b/docs/integration-testing/exposed-effects.md
@@ -75,11 +75,9 @@ it('exposes effects using async functions', async () => {
 
 ## Inspect Specific Properties
 
-If you want to inspect specific properties on an effect, you can use the
-`asEffect` util from Redux Saga.
+If you want to inspect specific properties on an effect, you can inspect the returned `effects` object.
 
 ```js
-import { asEffect } from 'redux-saga/utils';
 
 it('can test properties on effects', () => {
   const id = 42;
@@ -97,7 +95,7 @@ it('can test properties on effects', () => {
     .then((result) => {
       const { effects } = result;
 
-      const fetchUserCall = asEffect.call(effects.call[0]);
+      const fetchUserCall = effects.call[0].payload;
 
       expect(fetchUserCall.fn).toBe(fetchUser);
       expect(fetchUserCall.args).toEqual([42]);


### PR DESCRIPTION
According to the documentation there is a method available called `asEffect` available from the `redux-saga/utils` package - see here for more (Inspect Specific Properties): http://redux-saga-test-plan.jeremyfairbank.com/integration-testing/exposed-effects.html

This is no longer available from as the  `redux-saga/utils` package no longer exists. (https://github.com/redux-saga/redux-saga/issues/2145)

Not an issue for testing as you can still just inspect the `effects` object returned.