### PR TITLE
Fixes inferred args type of expectSaga and testSaga

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -114,14 +114,14 @@ export type TestApiWithEffectsTesters = TestApi & TestApiEffects & {
     returns<V>(returnValue: V): TestApi;
 };
 
-export type SagaType = (...params: any[]) => SagaIterator | IterableIterator<any>;
+export type SagaType<Args extends any[]> = (...params: Args) => SagaIterator | IterableIterator<any>;
 
-export const expectSaga: (<S extends SagaType>(
-  generator: S,
-  ...sagaArgs: Parameters<S>
+export const expectSaga: (<Args extends any[]>(
+  generator: SagaType<Args>,
+  ...sagaArgs: Args
 ) => ExpectApi) & { DEFAULT_TIMEOUT: number };
 
-export const testSaga: <S extends SagaType>(
-  saga: S,
-  ...params: Parameters<S>
+export const testSaga: <Args extends any[]>(
+  generator: SagaType<Args>,
+  ...sagaArgs: Args
 ) => TestApi;


### PR DESCRIPTION
This makes a small tweak to how the parameters for a saga given to `expectSaga` or `testSaga` are inferred.

This snippet does not work with the latest version, 4.0.4 and TypeScript 4.6

```ts
function* helperSaga<T>(foo: T, saga: (item: T) => any) {
  yield saga(channel);
}

function* handler(num: number) {
  yield num;
}

expectSaga(helperSaga, 42, handler);
```

The TypeScript compiler has an error on the last line:

```
function handler(num: number): Generator<number, void, unknown>
Argument of type '(num: number) => Generator<number, void, unknown>' is not assignable to parameter of type '(item: unknown) => any'.
  Types of parameters 'num' and 'item' are incompatible.
    Type 'unknown' is not assignable to type 'number'.ts(2345)
```

By making the type for the saga's params inferred as a generic type parameter and passing that through to `SagaType` as a type parameter, the compiler infers them correctly and the error is resolved.