### PR TITLE
remove unsupported polyfills.

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,11 +78,9 @@
     "rimraf": "^2.5.4"
   },
   "dependencies": {
-    "core-js": "^2.4.1",
     "fsm-iterator": "^1.1.0",
     "lodash.isequal": "^4.5.0",
-    "lodash.ismatch": "^4.4.0",
-    "object-assign": "^4.1.0"
+    "lodash.ismatch": "^4.4.0"
   },
   "peerDependencies": {
     "redux-saga": "^1.0.1",

--- a/src/expectSaga/index.js
+++ b/src/expectSaga/index.js
@@ -3,9 +3,7 @@
 import { runSaga, stdChannel } from 'redux-saga';
 import * as is from '@redux-saga/is';
 import * as effects from 'redux-saga/effects';
-import assign from 'object-assign';
 import { splitAt } from '../utils/array';
-import Map from '../utils/Map';
 import ArraySet from '../utils/ArraySet';
 import { warn } from '../utils/logging';
 import { delay, schedule } from '../utils/async';
@@ -588,7 +586,7 @@ export default function expectSaga(
     let dispatchableAction;
 
     if (typeof delayTime === 'number') {
-      dispatchableAction = assign({}, action, {
+      dispatchableAction = Object.assign({}, action, {
         _delayTime: delayTime,
       });
 

--- a/src/expectSaga/matchers/helpers.js
+++ b/src/expectSaga/matchers/helpers.js
@@ -1,5 +1,4 @@
 // @flow
-import assign from 'object-assign';
 
 const PARTIAL_MATCH = '@@redux-saga-test-plan/partial-matcher';
 
@@ -11,7 +10,7 @@ export function wrapEffectCreator(effectCreator: Function): Function {
 
 export function like(providerKey: string, defaults?: Object = {}): Function {
   return function effectMatcher(effect: Object): Object {
-    return assign({}, defaults, {
+    return Object.assign({}, defaults, {
       effect,
       providerKey,
       [PARTIAL_MATCH]: true,

--- a/src/testSaga/index.js
+++ b/src/testSaga/index.js
@@ -1,6 +1,5 @@
 // @flow
 import isEqual from 'lodash.isequal';
-import assign from 'object-assign';
 
 import * as effects from 'redux-saga/effects';
 
@@ -167,7 +166,7 @@ export default function testSaga(saga: Function, ...sagaArgs: Array<any>): Api {
     value,
     done,
   }: IteratorResult<*, *>): ApiWithEffectsTesters {
-    const newApi = assign({}, api, {
+    const newApi = Object.assign({}, api, {
       actionChannel: effectsTestersCreators.actionChannel(value),
       all: effectsTestersCreators.all(value),
       apply: effectsTestersCreators.apply(value),

--- a/src/utils/Map.js
+++ b/src/utils/Map.js
@@ -1,4 +1,0 @@
-// @flow
-export default (typeof Map !== 'undefined'
-  ? Map
-  : require('core-js/library/es6/map'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,10 +2006,6 @@ core-js-compat@^3.6.2:
     browserslist "^4.8.5"
     semver "7.0.0"
 
-core-js@^2.4.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
Remove polyfills for non supported node versions. on https://github.com/jfairbank/redux-saga-test-plan/releases/tag/4.0.0 it was removed the support for versions below 8.0.0

- Object assign https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#browser_compatibility (node v4.0)

- Map https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#browser_compatibility (node v0.12)

Fixes https://github.com/jfairbank/redux-saga-test-plan/issues/334 https://github.com/jfairbank/redux-saga-test-plan/issues/327