### PR TITLE
build: publish Flow declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "*.d.ts"
   ],
   "scripts": {
-    "build": "babel src --out-dir lib --ignore **/*/__mocks__",
+    "build": "babel src --out-dir lib --ignore **/*/__mocks__ && npm run copy-flow-decls",
     "check": "npm run lint && npm run typecheck && npm test",
     "clean": "rimraf lib",
+    "copy-flow-decls": "node -e \"require('fs').copyFileSync('decls/index.js', 'lib/index.js.flow')\"",
     "format": "prettier --write \"{src,__tests__}/**/*.js\"",
     "lint": "eslint src/ __tests__/",
     "prepublishOnly": "npm run clean && npm run build",


### PR DESCRIPTION
Fixes https://github.com/jfairbank/redux-saga-test-plan/issues/75

IssueHunt bounty: https://issuehunt.io/repos/57166630/issues/75 ($20)

## Summary
- copy the existing Flow libdef to `lib/index.js.flow` during the publish build
- keep the existing `decls/index.js` source of truth unchanged
- make the compiled package entrypoint expose Flow declarations automatically

## Verification
- `nvm exec 16 yarn build`
- `test -f lib/index.js.flow`
- `cmp -s decls/index.js lib/index.js.flow`
- `nvm exec 16 yarn typecheck`
- `nvm exec 16 npm pack --dry-run --json` confirmed `lib/index.js.flow` is included
- `nvm exec 16 yarn test:ci` (77 suites / 545 tests passed)
- `git diff --check`

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#75: Export flow type definitions in npm package](https://issuehunt.io/repos/57166630/issues/75)
---
</details>
<!-- /Issuehunt content-->